### PR TITLE
add key to connection statuses

### DIFF
--- a/src/Titlebar.tsx
+++ b/src/Titlebar.tsx
@@ -180,6 +180,7 @@ function Titlebar() {
             {Object.values(connectionStatuses).map((status) => {
               return (
                 <div
+                  key={`title-item-${status.label}`}
                   style={{
                     display: "flex",
                     alignItems: "center",


### PR DESCRIPTION
Added a key to the connection statuses in the title bar. First PR just to get my feet wet.

Fixes React warning in the console similar to this one: 
![image](https://github.com/frc-web-components/react-dashboard/assets/11887852/35c6b23c-d986-4dbd-9cba-d90b9c8d8a5b)

I didn't fix that specific one because it's a bug in the layout component itself, not this repo.

