### PR TITLE
add ability to delete components w/ backspace and delete keys

### DIFF
--- a/src/store/slices/layoutSlice.ts
+++ b/src/store/slices/layoutSlice.ts
@@ -104,8 +104,7 @@ export const layoutSlice = createAppSlice({
       (state, action: PayloadAction<{ componentId: string }>) => {
         const { componentId } = action.payload;
         const component = state.components[componentId];
-
-        let tabId = Object.keys(state.tabs).find((id) => {
+        const tabId = Object.keys(state.tabs).find((id) => {
           return state.tabs[id].componentIds.includes(componentId);
         });
 

--- a/src/tab/Tab.tsx
+++ b/src/tab/Tab.tsx
@@ -10,6 +10,7 @@ import {
   addComponent,
   updateComponentPosition,
   updateComponentSize,
+  removeComponent,
 } from "../store/slices/layoutSlice";
 import {
   makeSelectSelectedComponent,
@@ -30,6 +31,7 @@ import { selectEditing, setContextMenuElement } from "../store/slices/appSlice";
 import { SourceData } from "../tools/sources/Sources";
 import { getContextMenuPosition } from "./context-menu/useContextMenu";
 import ContextMenu from "./context-menu/ContextMenu";
+import { DELETE_KEYS } from "./constants";
 
 export const getComponentsWithDisplayType = (
   type: string,
@@ -262,6 +264,13 @@ function Tab({ tabId }: Props) {
         minHeight: "100%",
         minWidth,
         width: "100%",
+      }}
+      // Needed to capture keyboard events.
+      tabIndex={0}
+      onKeyDown={(e: React.KeyboardEvent) => {
+        if (DELETE_KEYS.includes(e.key) && selectedComponent) {
+          dispatch(removeComponent({ componentId: selectedComponent.id }));
+        }
       }}
     >
       <ContextMenu />

--- a/src/tab/constants.ts
+++ b/src/tab/constants.ts
@@ -1,0 +1,1 @@
+export const DELETE_KEYS: string[] = ["Delete", "Backspace"];


### PR DESCRIPTION
Quality of life edit: delete selected component with Delete and Backspace keys. 

The only weird bit of this is that all tabs have `tabIndex` set to 0 so they can receive keyboard events. I tabbed around a bit and didn't see any adverse effects, but open to suggestions on how to do this differently.


https://github.com/frc-web-components/react-dashboard/assets/11887852/889e6307-2e83-46dd-bf76-9dbf06963a88

