### PR TITLE
Echarles/intro tooltips

### DIFF
--- a/src/components/fromProps.ts
+++ b/src/components/fromProps.ts
@@ -2,6 +2,10 @@ import { ReactNode } from "react";
 import { ComponentProperty } from "../context-providers/ComponentConfigContext";
 import { ComponentConfig } from "../context-providers/ComponentConfigContext";
 
+type BaseProp<T> = {
+  defaultValue?: T;
+  tooltip?: string;
+};
 // Define a mapping from your string literals to TypeScript types
 type TypeMappings = {
   Number: number;
@@ -57,15 +61,15 @@ export function createComponent<P extends Record<string, ComponentProperty>>(
   };
 }
 
-export function numberProp(prop?: {
-  defaultValue?: number;
-  min?: number;
-  max?: number;
-  step?: number;
-  precision?: number;
-}): {
+export function numberProp(
+  prop?: BaseProp<number> & {
+    min?: number;
+    max?: number;
+    step?: number;
+    precision?: number;
+  }
+): BaseProp<number> & {
   type: "Number";
-  defaultValue: number;
   input: {
     type: "Number";
     min?: number;
@@ -77,6 +81,7 @@ export function numberProp(prop?: {
   return {
     type: "Number",
     defaultValue: prop?.defaultValue ?? 0,
+    tooltip: prop?.tooltip,
     input: {
       type: "Number",
       min: prop?.min,
@@ -87,23 +92,23 @@ export function numberProp(prop?: {
   };
 }
 
-export function stringProp(prop?: { defaultValue?: string }): {
+export function stringProp(prop?: BaseProp<string>): BaseProp<string> & {
   type: "String";
-  defaultValue: string;
 } {
   return {
     type: "String",
     defaultValue: prop?.defaultValue ?? "",
+    tooltip: prop?.tooltip,
   };
 }
 
-export function stringDropdownProp(prop?: {
-  defaultValue?: string;
-  options?: string[] | ((propValues: Record<string, any>) => string[]);
-  allowCustomValues?: boolean;
-}): {
+export function stringDropdownProp(
+  prop?: BaseProp<string> & {
+    options?: string[] | ((propValues: Record<string, any>) => string[]);
+    allowCustomValues?: boolean;
+  }
+): BaseProp<string> & {
   type: "String";
-  defaultValue: string;
   input: {
     type: "StringDropdown";
     options: string[] | ((propValues: Record<string, any>) => string[]);
@@ -113,6 +118,7 @@ export function stringDropdownProp(prop?: {
   return {
     type: "String",
     defaultValue: prop?.defaultValue ?? "",
+    tooltip: prop?.tooltip,
     input: {
       type: "StringDropdown",
       options: prop?.options ?? [],
@@ -121,9 +127,8 @@ export function stringDropdownProp(prop?: {
   };
 }
 
-export function colorProp(prop?: { defaultValue?: string }): {
+export function colorProp(prop?: BaseProp<string>): BaseProp<string> & {
   type: "String";
-  defaultValue: string;
   input: {
     type: "Color";
   };
@@ -131,15 +136,15 @@ export function colorProp(prop?: { defaultValue?: string }): {
   return {
     type: "String",
     defaultValue: prop?.defaultValue ?? "",
+    tooltip: prop?.tooltip,
     input: {
       type: "Color",
     },
   };
 }
 
-export function markdownProp(prop?: { defaultValue?: string }): {
+export function markdownProp(prop?: BaseProp<string>): BaseProp<string> & {
   type: "String";
-  defaultValue: string;
   input: {
     type: "Markdown";
   };
@@ -147,38 +152,43 @@ export function markdownProp(prop?: { defaultValue?: string }): {
   return {
     type: "String",
     defaultValue: prop?.defaultValue ?? "",
+    tooltip: prop?.tooltip,
     input: {
       type: "Markdown",
     },
   };
 }
 
-export function booleanProp(prop?: { defaultValue?: boolean }): {
+export function booleanProp(prop?: BaseProp<boolean>): BaseProp<boolean> & {
   type: "Boolean";
-  defaultValue: boolean;
 } {
   return {
     type: "Boolean",
+    tooltip: prop?.tooltip,
     defaultValue: prop?.defaultValue ?? false,
   };
 }
 
-export function numberArrayProp(prop?: { defaultValue?: number[] }): {
+export function numberArrayProp(prop?: BaseProp<number[]>): BaseProp<
+  number[]
+> & {
   type: "Number[]";
-  defaultValue: number[];
 } {
   return {
     type: "Number[]",
     defaultValue: prop?.defaultValue ?? [],
+    tooltip: prop?.tooltip,
   };
 }
 
-export function stringArrayProp(prop?: { defaultValue?: string[] }): {
+export function stringArrayProp(prop?: BaseProp<string[]>): BaseProp<
+  string[]
+> & {
   type: "String[]";
-  defaultValue: string[];
 } {
   return {
     type: "String[]",
     defaultValue: prop?.defaultValue ?? [],
+    tooltip: prop?.tooltip,
   };
 }

--- a/src/components/fromProps.ts
+++ b/src/components/fromProps.ts
@@ -3,8 +3,8 @@ import { ComponentProperty } from "../context-providers/ComponentConfigContext";
 import { ComponentConfig } from "../context-providers/ComponentConfigContext";
 
 type BaseProp<T> = {
-  defaultValue?: T;
-  tooltip?: string;
+  defaultValue: T;
+  tooltip: string;
 };
 // Define a mapping from your string literals to TypeScript types
 type TypeMappings = {
@@ -62,13 +62,13 @@ export function createComponent<P extends Record<string, ComponentProperty>>(
 }
 
 export function numberProp(
-  prop?: BaseProp<number> & {
+  prop?: Partial<BaseProp<number>> & {
     min?: number;
     max?: number;
     step?: number;
     precision?: number;
   }
-): BaseProp<number> & {
+): Partial<BaseProp<number>> & {
   type: "Number";
   input: {
     type: "Number";
@@ -92,7 +92,9 @@ export function numberProp(
   };
 }
 
-export function stringProp(prop?: BaseProp<string>): BaseProp<string> & {
+export function stringProp(prop?: Partial<BaseProp<string>>): Partial<
+  BaseProp<string>
+> & {
   type: "String";
 } {
   return {
@@ -103,11 +105,11 @@ export function stringProp(prop?: BaseProp<string>): BaseProp<string> & {
 }
 
 export function stringDropdownProp(
-  prop?: BaseProp<string> & {
+  prop?: Partial<BaseProp<string>> & {
     options?: string[] | ((propValues: Record<string, any>) => string[]);
     allowCustomValues?: boolean;
   }
-): BaseProp<string> & {
+): Partial<BaseProp<string>> & {
   type: "String";
   input: {
     type: "StringDropdown";
@@ -127,7 +129,9 @@ export function stringDropdownProp(
   };
 }
 
-export function colorProp(prop?: BaseProp<string>): BaseProp<string> & {
+export function colorProp(prop?: Partial<BaseProp<string>>): Partial<
+  BaseProp<string>
+> & {
   type: "String";
   input: {
     type: "Color";
@@ -143,7 +147,9 @@ export function colorProp(prop?: BaseProp<string>): BaseProp<string> & {
   };
 }
 
-export function markdownProp(prop?: BaseProp<string>): BaseProp<string> & {
+export function markdownProp(prop?: Partial<BaseProp<string>>): Partial<
+  BaseProp<string>
+> & {
   type: "String";
   input: {
     type: "Markdown";
@@ -159,7 +165,9 @@ export function markdownProp(prop?: BaseProp<string>): BaseProp<string> & {
   };
 }
 
-export function booleanProp(prop?: BaseProp<boolean>): BaseProp<boolean> & {
+export function booleanProp(prop?: Partial<BaseProp<boolean>>): Partial<
+  BaseProp<boolean>
+> & {
   type: "Boolean";
 } {
   return {
@@ -169,8 +177,8 @@ export function booleanProp(prop?: BaseProp<boolean>): BaseProp<boolean> & {
   };
 }
 
-export function numberArrayProp(prop?: BaseProp<number[]>): BaseProp<
-  number[]
+export function numberArrayProp(prop?: Partial<BaseProp<number[]>>): Partial<
+  BaseProp<number[]>
 > & {
   type: "Number[]";
 } {
@@ -181,8 +189,8 @@ export function numberArrayProp(prop?: BaseProp<number[]>): BaseProp<
   };
 }
 
-export function stringArrayProp(prop?: BaseProp<string[]>): BaseProp<
-  string[]
+export function stringArrayProp(prop?: Partial<BaseProp<string[]>>): Partial<
+  BaseProp<string[]>
 > & {
   type: "String[]";
 } {

--- a/src/context-providers/ComponentConfigContext.tsx
+++ b/src/context-providers/ComponentConfigContext.tsx
@@ -11,7 +11,7 @@ export interface ComponentProperty {
     | "String[]"
     | "Boolean[]"
     | "Object[]";
-  defaultValue?: unknown;
+  defaultValue: unknown;
   input?: {
     type: string;
     [props: string]: unknown;

--- a/src/context-providers/ComponentConfigContext.tsx
+++ b/src/context-providers/ComponentConfigContext.tsx
@@ -11,11 +11,12 @@ export interface ComponentProperty {
     | "String[]"
     | "Boolean[]"
     | "Object[]";
-  defaultValue: unknown;
+  defaultValue?: unknown;
   input?: {
     type: string;
     [props: string]: unknown;
   };
+  tooltip?: string;
 }
 
 export interface ChildComponentConfig {

--- a/src/tools/properties/ParentActionsCellRenderer.tsx
+++ b/src/tools/properties/ParentActionsCellRenderer.tsx
@@ -14,6 +14,7 @@ import {
 import { useComponentConfigs } from "../../context-providers/ComponentConfigContext";
 import { addComponent, removeComponent } from "../../store/slices/layoutSlice";
 import { v4 as uuidv4 } from "uuid";
+import Tooltip from "@mui/material/Tooltip";
 
 export const ParentActionsCellRenderer = (
   props: CustomCellRendererProps<
@@ -102,24 +103,26 @@ export const ParentActionsCellRenderer = (
           <AddCircleIcon fontSize="small" color="success" />
         </button>
       )}
-      <button
-        className={styles["action-buttons"]}
-        style={{
-          fontSize: "20px",
-          lineHeight: "20px",
-        }}
-        onClick={() => {
-          if (!component) {
-            return;
-          }
-          dispatch(removeComponent({ componentId: component.id }));
-          // if (typeof props.data?.index === "number") {
-          //   props.context.addElementAfter(props.data.index);
-          // }
-        }}
-      >
-        <RemoveCircleIcon fontSize="small" color="error" />
-      </button>
+      <Tooltip title={"Remove component"}>
+        <button
+          className={styles["action-buttons"]}
+          style={{
+            fontSize: "20px",
+            lineHeight: "20px",
+          }}
+          onClick={() => {
+            if (!component) {
+              return;
+            }
+            dispatch(removeComponent({ componentId: component.id }));
+            // if (typeof props.data?.index === "number") {
+            //   props.context.addElementAfter(props.data.index);
+            // }
+          }}
+        >
+          <RemoveCircleIcon fontSize="small" color="error" />
+        </button>
+      </Tooltip>
     </div>
   );
 };

--- a/src/tools/properties/Properties.tsx
+++ b/src/tools/properties/Properties.tsx
@@ -44,6 +44,7 @@ export interface PropertyData {
   type: string;
   defaultValue: unknown;
   componentConfig: ComponentConfig;
+  tooltip?: string;
 }
 
 export interface PropertyContext {
@@ -58,6 +59,7 @@ const defaultColumnDefs: ColDef<PropertyData>[] = [
     editable: (params) => {
       return !!params.data?.isParent;
     },
+    tooltipValueGetter: (p) => p.data?.tooltip,
     sortable: false,
     cellRenderer: PropertyNameCellRenderer,
   },
@@ -313,6 +315,7 @@ function Properties({ childComponentConfig, configType }: Props) {
                   type: property.input?.type ?? property.type,
                   source: properties[name].source,
                   componentConfig,
+                  tooltip: property.tooltip,
                 };
               }
             ) ?? [];
@@ -442,6 +445,7 @@ function Properties({ childComponentConfig, configType }: Props) {
             rowDragManaged={true}
             suppressMoveWhenRowDragging={true}
             suppressRowDrag={true}
+            tooltipShowDelay={0.25}
             getRowId={(params) => {
               if (!params.data.isParent) {
                 return `${params.data.componentId}-${params.data.name}`;


### PR DESCRIPTION
Introduces two kinds of tooltips: 

1. MaterialUI tooltips for non-component UI elements. Added this as an example: 
![image](https://github.com/frc-web-components/react-dashboard/assets/11887852/eb39aaec-53ef-4439-9af4-70fa56cd3ee3)
2. Property-specific tooltips. These attach to the metadata of component properties, and are displayed on hover in the Properties layout: 

https://github.com/frc-web-components/react-dashboard/assets/11887852/f1216efd-d624-4a18-8e38-28f17f82ff52


I didn't commit the property tooltips in the video above, this PR just puts the framework in place. 
